### PR TITLE
Build perf improvement for OCCT dependency.

### DIFF
--- a/deps/OCCT/OCCT.cmake
+++ b/deps/OCCT/OCCT.cmake
@@ -5,6 +5,7 @@ prusaslicer_add_cmake_project(OCCT
 
     PATCH_COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/occt_toolkit.cmake ./adm/cmake/
     CMAKE_ARGS
+      -DBUILD_USE_PCH=ON
         -DINSTALL_DIR_LAYOUT=Unix # LMBBS
         -DBUILD_LIBRARY_TYPE=Static
         -DUSE_TK=OFF


### PR DESCRIPTION
Got a 10-15% build time improvement by adding PCH flag to OCCT.cmake